### PR TITLE
Make usingAPI easier to use

### DIFF
--- a/app/src/commonMain/kotlin/sdu/mobile/xpence/ui/utils/API.kt
+++ b/app/src/commonMain/kotlin/sdu/mobile/xpence/ui/utils/API.kt
@@ -19,6 +19,6 @@ data class TokenInfo(
 data class Group(val id: Int, val name: String)
 
 // API CALLS
-suspend fun getGroups(client: HttpClient): Result<Array<Group>> {
-    return Result.Success(client.get("https://xpense-api.gredal.dev/groups").body<Array<Group>>())
+suspend fun getGroups(client: HttpClient): Array<Group> {
+    return client.get("https://xpense-api.gredal.dev/groups").body<Array<Group>>()
 }


### PR DESCRIPTION
This removes the result class, and instead api wrappers should throw on error conditions. This will make it easier to compose multiple api calls together